### PR TITLE
レビューする相手のリスト画面の実装

### DIFF
--- a/mobile/lib/features/home/home_page.dart
+++ b/mobile/lib/features/home/home_page.dart
@@ -22,7 +22,7 @@ class _HomePageState extends ConsumerState<HomePage> {
 
     final body = <Widget>[
       const WorkSwipeDeck(),
-      const _PlaceholderPage(text: '相手へのレビュー'),
+      const ReviewListScreen(),
       const _PlaceholderPage(text: '作品投稿'),
       const AcceptedReviewListPage(),
       _ProfilePage(
@@ -40,20 +40,7 @@ class _HomePageState extends ConsumerState<HomePage> {
       ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: _index,
-        onDestinationSelected: (value) async {
-          if (value == 1) {
-            await Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const ReviewScreen(
-                  artworkId: 'artwork_123',
-                  artworkImageUrl: 'https://picsum.photos/400/300',
-                  artworkTitle: '夕暮れの街',
-                  artistName: '山田太郎',
-                ),
-              ),
-            );
-            return;
-          }
+        onDestinationSelected: (value) {
           setState(() => _index = value);
         },
         destinations: const [

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -1,328 +1,160 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 
-class ReviewScreen extends StatefulWidget {
-  final String artworkId;
-  final String artworkImageUrl;
+// レビュー対象のデータモデル
+class ReviewTarget {
+  final String id;
+  final String userName;
   final String artworkTitle;
-  final String artistName;
 
-  const ReviewScreen({
-    super.key,
-    required this.artworkId,
-    required this.artworkImageUrl,
+  const ReviewTarget({
+    required this.id,
+    required this.userName,
     required this.artworkTitle,
-    required this.artistName,
   });
-
-  @override
-  State<ReviewScreen> createState() => _ReviewScreenState();
 }
 
-class _ReviewScreenState extends State<ReviewScreen> {
-  // ---- 設定 ----
-  static const String reviewEndpoint =
-      'https://example.com/api/reviews'; // TODO: 自分のAPIへ
-  static const String userId = 'uuid'; // 本来は認証から取得
-  static const int maxCommentLength = 500;
-  // -------------
+class ReviewListScreen extends StatelessWidget {
+  const ReviewListScreen({super.key});
 
-  final _formKey = GlobalKey<FormState>();
-  final _commentCtrl = TextEditingController();
-
-  bool _isSubmitting = false;
-
-  @override
-  void dispose() {
-    _commentCtrl.dispose();
-    super.dispose();
-  }
-
-  bool _canSubmit() {
-    final comment = _commentCtrl.text.trim();
-    return comment.isNotEmpty && comment.length <= maxCommentLength;
-  }
-
-  Future<void> _submitReview() async {
-    if (!_formKey.currentState!.validate()) return;
-    if (!_canSubmit()) return;
-
-    setState(() => _isSubmitting = true);
-
-    try {
-      final payload = {
-        'user_id': userId,
-        'artwork_id': widget.artworkId,
-        'comment': _commentCtrl.text.trim(),
-      };
-
-      final res = await http.post(
-        Uri.parse(reviewEndpoint),
-        headers: {
-          'Content-Type': 'application/json',
-          // 'Authorization': 'Bearer ...', // 必要なら
-        },
-        body: jsonEncode(payload),
-      );
-
-      if (!mounted) return;
-
-      if (res.statusCode >= 200 && res.statusCode < 300) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('レビューを送信しました')),
-        );
-        // 送信後に前の画面に戻る
-        Navigator.pop(context);
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('送信失敗: ${res.statusCode}\n${res.body}')),
-        );
-      }
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('通信エラー: $e')),
-      );
-    } finally {
-      if (mounted) setState(() => _isSubmitting = false);
-    }
+  // ダミーデータ（実際にはAPIから取得）
+  List<ReviewTarget> _getReviewTargets() {
+    return [
+      const ReviewTarget(id: '1', userName: '山田太郎', artworkTitle: '夕暮れの風景'),
+      const ReviewTarget(id: '2', userName: '佐藤花子', artworkTitle: '抽象的な表現'),
+      const ReviewTarget(id: '3', userName: '田中一郎', artworkTitle: '都会の夜'),
+      const ReviewTarget(id: '4', userName: '鈴木美咲', artworkTitle: '自然の美しさ'),
+      const ReviewTarget(id: '5', userName: '高橋健太', artworkTitle: 'ポートレート'),
+    ];
   }
 
   @override
   Widget build(BuildContext context) {
+    final reviewTargets = _getReviewTargets();
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('レビューを送る'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.pop(context),
-        ),
-        actions: [
-          IconButton(
-            icon: Container(
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.all(color: Colors.grey[700]!, width: 2),
-              ),
-              child: Center(
-                child: Text(
-                  '?',
-                  style: TextStyle(
-                    color: Colors.grey[700],
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
+      // appBar: AppBar(
+      //   title: const Text('レビュー待ちリスト'),
+      //   elevation: 0,
+      // ),
+      body: reviewTargets.isEmpty
+          ? const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.inbox_outlined, size: 64, color: Colors.grey),
+                  SizedBox(height: 16),
+                  Text(
+                    'レビュー待ちの作品はありません',
+                    style: TextStyle(fontSize: 16, color: Colors.grey),
                   ),
-                ),
+                ],
               ),
+            )
+          : ListView.builder(
+              itemCount: reviewTargets.length,
+              padding: const EdgeInsets.all(16),
+              itemBuilder: (context, index) {
+                final target = reviewTargets[index];
+                return _ReviewTargetCard(target: target);
+              },
             ),
-            onPressed: () {
-              showDialog(
-                context: context,
-                builder: (BuildContext context) {
-                  return AlertDialog(
-                    title: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    );
+  }
+}
+
+class _ReviewTargetCard extends StatelessWidget {
+  final ReviewTarget target;
+
+  const _ReviewTargetCard({required this.target});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      elevation: 2,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        onTap: () {
+          // レビュー画面への遷移（実装予定）
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('${target.userName}の「${target.artworkTitle}」をレビュー'),
+            ),
+          );
+        },
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  CircleAvatar(
+                    backgroundColor: Theme.of(context).primaryColor,
+                    child: Text(
+                      target.userName[0].toUpperCase(),
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const Row(
-                          children: [
-                            Icon(Icons.help_outline, color: Colors.blue),
-                            SizedBox(width: 8),
-                            Text('レビューの書き方'),
-                          ],
-                        ),
-                        IconButton(
-                          padding: EdgeInsets.zero,
-                          constraints: const BoxConstraints(),
-                          icon: Container(
-                            width: 28,
-                            height: 28,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.grey[300],
-                            ),
-                            child: const Icon(
-                              Icons.close,
-                              size: 18,
-                              color: Colors.black87,
-                            ),
+                        Text(
+                          target.userName,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
                           ),
-                          onPressed: () => Navigator.pop(context),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'レビュー待ち',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey[600],
+                          ),
                         ),
                       ],
                     ),
-                    content: const SingleChildScrollView(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            '良いレビューのポイント：',
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 16,
-                            ),
-                          ),
-                          SizedBox(height: 12),
-                          Text('• 作品の良い点を具体的に伝える'),
-                          SizedBox(height: 8),
-                          Text('• 改善できる点は建設的に提案する'),
-                          SizedBox(height: 8),
-                          Text('• 作者の意図や努力を認める'),
-                          SizedBox(height: 8),
-                          Text('• 丁寧で前向きな言葉を使う'),
-                          SizedBox(height: 16),
-                          Text(
-                            '例：「色使いが素晴らしいですね！構図をもう少し工夫すると、さらに印象的になると思います。」',
-                            textAlign: TextAlign.center,
-                            style: TextStyle(
-                              fontStyle: FontStyle.italic,
-                              color: Colors.grey,
-                            ),
-                          ),
-                        ],
+                  ),
+                  Icon(Icons.chevron_right, color: Colors.grey[400]),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.grey[100],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.article_outlined,
+                      size: 20,
+                      color: Colors.grey[700],
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        target.artworkTitle,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Colors.grey[800],
+                          fontWeight: FontWeight.w500,
+                        ),
                       ),
                     ),
-                  );
-                },
-              );
-            },
-          ),
-        ],
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // 作品情報カード
-                Card(
-                  elevation: 2,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // 作品画像
-                      ClipRRect(
-                        borderRadius: const BorderRadius.vertical(
-                          top: Radius.circular(12),
-                        ),
-                        child: Image.network(
-                          widget.artworkImageUrl,
-                          width: double.infinity,
-                          height: 250,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) {
-                            return Container(
-                              height: 250,
-                              color: Colors.grey[300],
-                              child: const Center(
-                                child: Icon(Icons.broken_image, size: 64),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                      // 作品タイトルとアーティスト名
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              widget.artworkTitle,
-                              style: const TextStyle(
-                                fontSize: 18,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              'by ${widget.artistName}',
-                              style: TextStyle(
-                                fontSize: 14,
-                                color: Colors.grey[600],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+                  ],
                 ),
-
-                const SizedBox(height: 24),
-
-                // レビュー入力セクション
-                const Text(
-                  'レビューコメント',
-                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 8),
-                TextFormField(
-                  controller: _commentCtrl,
-                  enabled: !_isSubmitting,
-                  decoration: InputDecoration(
-                    hintText: 'この作品への感想やアドバイスを書いてください',
-                    border: const OutlineInputBorder(),
-                    counterText:
-                        '${_commentCtrl.text.length}/$maxCommentLength',
-                  ),
-                  maxLines: 6,
-                  maxLength: maxCommentLength,
-                  onChanged: (_) => setState(() {}), // ボタンの状態更新のため
-                  validator: (v) {
-                    if (v == null || v.trim().isEmpty) {
-                      return 'コメントを入力してください。';
-                    }
-                    if (v.length > maxCommentLength) {
-                      return 'コメントは$maxCommentLength文字以内にしてください。';
-                    }
-                    return null;
-                  },
-                ),
-
-                const SizedBox(height: 20),
-
-                // 送信ボタン
-                ElevatedButton(
-                  onPressed: _isSubmitting
-                      ? null
-                      : (_canSubmit() ? _submitReview : null),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: _canSubmit() && !_isSubmitting
-                        ? Colors.blue
-                        : null,
-                    foregroundColor: _canSubmit() && !_isSubmitting
-                        ? Colors.white
-                        : null,
-                    minimumSize: const Size(double.infinity, 48),
-                  ),
-                  child: _isSubmitting
-                      ? const SizedBox(
-                          height: 18,
-                          width: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Colors.white,
-                          ),
-                        )
-                      : Text(
-                          _canSubmit()
-                              ? 'レビューを送信'
-                              : 'コメントを入力してください',
-                          style: const TextStyle(fontSize: 16),
-                        ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/mobile/lib/upload.dart
+++ b/mobile/lib/upload.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:convert';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:http/http.dart' as http;


### PR DESCRIPTION
## 概要
レビューする相手のユーザー名と作品名を表示するリスト画面を実装しました。

## 変更内容
- **ReviewListScreen**: レビュー対象者のリスト表示画面を実装
- **ホーム画面への統合**: BottomNavigationBarから直接アクセス可能に
- **UIデザインの統一**: 受信レビュー画面と同じデザインパターンを採用
  - Cardベースのレイアウト
  - CircleAvatarでユーザーのイニシャル表示
  - グレー背景ボックスで作品タイトル表示
- **コードクリーンアップ**: 未使用のimportを削除

## デザイン詳細
- Card elevation: 2
- Border radius: 12px
- Padding: 16px
- 受信レビュー画面と完全に統一されたUI

## 確認方法
1. アプリを起動
2. BottomNavigationBarの「レビューする」をタップ
3. レビュー対象者のリストが表示される
4. リストアイテムをタップするとスナックバーが表示される（レビュー画面への遷移は今後実装予定）

## スクリーンショット
（必要に応じて追加）