### PR TITLE
Home icons: remove heart button and use star on swipe

### DIFF
--- a/mobile/lib/features/home/widgets/work_card.dart
+++ b/mobile/lib/features/home/widgets/work_card.dart
@@ -60,15 +60,6 @@ class WorkCard extends StatelessWidget {
               ],
             ),
           ),
-          Positioned(
-            right: 12,
-            top: 12,
-            child: IconButton.filledTonal(
-              onPressed: onLike,
-              icon: const Icon(Icons.favorite),
-              tooltip: 'いいね',
-            ),
-          ),
         ],
       ),
     );

--- a/mobile/lib/features/home/widgets/work_swipe_deck.dart
+++ b/mobile/lib/features/home/widgets/work_swipe_deck.dart
@@ -110,7 +110,7 @@ class _DismissibleTopCard extends ConsumerWidget {
       },
       background: _SwipeBackground(
         alignment: Alignment.centerLeft,
-        icon: Icons.favorite,
+        icon: Icons.star,
         label: 'いいね',
         color: Theme.of(context).colorScheme.primaryContainer,
       ),


### PR DESCRIPTION
## Summary
- remove the heart button on work cards
- use a star icon for the like swipe background

## Testing
- not run (UI change)