### PR TITLE
受信レビュー一覧に統一し承認機能を削除

### DIFF
--- a/mobile/lib/features/home/home_page.dart
+++ b/mobile/lib/features/home/home_page.dart
@@ -5,7 +5,7 @@ import '../../review_screen.dart';
 import '../../upload.dart';
 import '../auth/auth_controller.dart';
 import '../profile/profile_edit_page.dart';
-import '../review/accepted_review_list_page.dart';
+import '../review/received_review_list_page.dart';
 import 'widgets/work_swipe_deck.dart';
 
 class HomePage extends ConsumerStatefulWidget {
@@ -26,7 +26,7 @@ class _HomePageState extends ConsumerState<HomePage> {
       const WorkSwipeDeck(),
       const ReviewListScreen(),
       const UploadArtworkPage(),
-      const AcceptedReviewListPage(),
+      const ReceivedReviewListPage(),
       ProfileEditPage(
         onLogout: () => ref.read(authControllerProvider.notifier).logout(),
       ),

--- a/mobile/lib/features/review/received_review_list_page.dart
+++ b/mobile/lib/features/review/received_review_list_page.dart
@@ -3,31 +3,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../accept_review_screen.dart';
 import 'review_service.dart';
 
-class AcceptedReviewListPage extends ConsumerStatefulWidget {
-  const AcceptedReviewListPage({super.key});
+class ReceivedReviewListPage extends ConsumerStatefulWidget {
+  const ReceivedReviewListPage({super.key});
 
   @override
-  ConsumerState<AcceptedReviewListPage> createState() =>
-      _AcceptedReviewListPageState();
+  ConsumerState<ReceivedReviewListPage> createState() =>
+      _ReceivedReviewListPageState();
 }
 
-class _AcceptedReviewListPageState
-    extends ConsumerState<AcceptedReviewListPage> {
+class _ReceivedReviewListPageState
+    extends ConsumerState<ReceivedReviewListPage> {
   @override
   void initState() {
     super.initState();
-    // ページ読み込み時に承認済みレビューを取得
+    // ページ読み込み時に受信レビューを取得
     Future.microtask(
-      () => ref.read(reviewServiceProvider).fetchAcceptedReviews(),
+      () => ref.read(reviewServiceProvider).fetchReceivedReviews(),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    final reviews = ref.watch(acceptedReviewsProvider);
+    final reviews = ref.watch(receivedReviewsProvider);
 
     return Scaffold(
-      //appBar: AppBar(title: const Text('承認済みレビュー'), elevation: 0),
       body: reviews.when(
         data: (reviewList) {
           if (reviewList.isEmpty) {
@@ -38,7 +37,7 @@ class _AcceptedReviewListPageState
                   Icon(Icons.inbox_outlined, size: 64, color: Colors.grey),
                   SizedBox(height: 16),
                   Text(
-                    'まだ承認済みレビューがありません',
+                    '受信レビューがまだありません',
                     style: TextStyle(fontSize: 16, color: Colors.grey),
                   ),
                 ],
@@ -48,7 +47,7 @@ class _AcceptedReviewListPageState
 
           return RefreshIndicator(
             onRefresh: () async {
-              await ref.read(reviewServiceProvider).fetchAcceptedReviews();
+              await ref.read(reviewServiceProvider).fetchReceivedReviews();
             },
             child: ListView.builder(
               padding: const EdgeInsets.all(16),
@@ -80,7 +79,7 @@ class _AcceptedReviewListPageState
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () {
-                  ref.read(reviewServiceProvider).fetchAcceptedReviews();
+                  ref.read(reviewServiceProvider).fetchReceivedReviews();
                 },
                 child: const Text('再試行'),
               ),
@@ -93,7 +92,7 @@ class _AcceptedReviewListPageState
 }
 
 class _ReviewCard extends StatelessWidget {
-  final AcceptedReview review;
+  final ReceivedReview review;
 
   const _ReviewCard({required this.review});
 

--- a/mobile/lib/features/review/review_service.dart
+++ b/mobile/lib/features/review/review_service.dart
@@ -1,13 +1,14 @@
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:http/http.dart' as http;
-import 'dart:convert';
 
 // フロントのみでUIを確認したい場合は true にする
-const bool _useMockAcceptedReviews = true;
+const bool _useMockReceivedReviews = true;
 
-// 承認済みレビューのデータモデル
-class AcceptedReview {
+// 受信レビューのデータモデル
+class ReceivedReview {
   final String id;
   final String userId;
   final String userName;
@@ -15,9 +16,8 @@ class AcceptedReview {
   final String? workId;
   final String? workTitle;
   final DateTime createdAt;
-  final bool isAccepted;
 
-  AcceptedReview({
+  ReceivedReview({
     required this.id,
     required this.userId,
     required this.userName,
@@ -25,11 +25,10 @@ class AcceptedReview {
     this.workId,
     this.workTitle,
     required this.createdAt,
-    required this.isAccepted,
   });
 
-  factory AcceptedReview.fromJson(Map<String, dynamic> json) {
-    return AcceptedReview(
+  factory ReceivedReview.fromJson(Map<String, dynamic> json) {
+    return ReceivedReview(
       id: json['id'] as String,
       userId: json['user_id'] as String,
       userName: json['user_name'] as String? ?? 'Unknown User',
@@ -37,14 +36,13 @@ class AcceptedReview {
       workId: json['work_id'] as String?,
       workTitle: json['work_title'] as String?,
       createdAt: DateTime.parse(json['created_at'] as String),
-      isAccepted: json['is_accepted'] as bool? ?? false,
     );
   }
 }
 
 // UI確認用のモックデータ
-final List<AcceptedReview> _mockAcceptedReviews = <AcceptedReview>[
-  AcceptedReview(
+final List<ReceivedReview> _mockReceivedReviews = <ReceivedReview>[
+  ReceivedReview(
     id: '1',
     userId: 'user1',
     userName: '田中太郎',
@@ -52,9 +50,8 @@ final List<AcceptedReview> _mockAcceptedReviews = <AcceptedReview>[
     workId: 'work1',
     workTitle: '夕焼けの風景画',
     createdAt: DateTime.now().subtract(const Duration(minutes: 5)),
-    isAccepted: true,
   ),
-  AcceptedReview(
+  ReceivedReview(
     id: '2',
     userId: 'user2',
     userName: '佐藤花子',
@@ -62,9 +59,8 @@ final List<AcceptedReview> _mockAcceptedReviews = <AcceptedReview>[
     workId: 'work2',
     workTitle: '都会の夜景',
     createdAt: DateTime.now().subtract(const Duration(hours: 2)),
-    isAccepted: true,
   ),
-  AcceptedReview(
+  ReceivedReview(
     id: '3',
     userId: 'user3',
     userName: '山田次郎',
@@ -72,9 +68,8 @@ final List<AcceptedReview> _mockAcceptedReviews = <AcceptedReview>[
     workId: null,
     workTitle: null,
     createdAt: DateTime.now().subtract(const Duration(days: 1)),
-    isAccepted: true,
   ),
-  AcceptedReview(
+  ReceivedReview(
     id: '4',
     userId: 'user4',
     userName: 'Mike Johnson',
@@ -82,9 +77,8 @@ final List<AcceptedReview> _mockAcceptedReviews = <AcceptedReview>[
     workId: 'work3',
     workTitle: '春の桜',
     createdAt: DateTime.now().subtract(const Duration(days: 3)),
-    isAccepted: true,
   ),
-  AcceptedReview(
+  ReceivedReview(
     id: '5',
     userId: 'user5',
     userName: '鈴木一郎',
@@ -92,12 +86,11 @@ final List<AcceptedReview> _mockAcceptedReviews = <AcceptedReview>[
     workId: 'work4',
     workTitle: '抽象画アート',
     createdAt: DateTime.now().subtract(const Duration(days: 10)),
-    isAccepted: true,
   ),
 ];
 
-// 承認済みレビューのリストを管理するプロバイダー
-final acceptedReviewsProvider = StateProvider<AsyncValue<List<AcceptedReview>>>(
+// 受信レビューのリストを管理するプロバイダー
+final receivedReviewsProvider = StateProvider<AsyncValue<List<ReceivedReview>>>(
   (ref) {
     return const AsyncValue.loading();
   },
@@ -113,16 +106,16 @@ class ReviewService {
 
   ReviewService(this.ref);
 
-  // 承認済みレビューを取得
-  Future<void> fetchAcceptedReviews() async {
-    ref.read(acceptedReviewsProvider.notifier).state =
+  // 受信レビューを取得
+  Future<void> fetchReceivedReviews() async {
+    ref.read(receivedReviewsProvider.notifier).state =
         const AsyncValue.loading();
 
     // モックデータでUI確認
-    if (_useMockAcceptedReviews) {
+    if (_useMockReceivedReviews) {
       await Future.delayed(const Duration(milliseconds: 400));
-      ref.read(acceptedReviewsProvider.notifier).state = AsyncValue.data(
-        _mockAcceptedReviews,
+      ref.read(receivedReviewsProvider.notifier).state = AsyncValue.data(
+        _mockReceivedReviews,
       );
       return;
     }
@@ -141,54 +134,22 @@ class ReviewService {
       if (response.statusCode == 200) {
         final List<dynamic> data = json.decode(response.body);
         final reviews = data
-            .map((json) => AcceptedReview.fromJson(json))
+            .map((json) => ReceivedReview.fromJson(json))
             .toList();
 
-        ref.read(acceptedReviewsProvider.notifier).state = AsyncValue.data(
+        ref.read(receivedReviewsProvider.notifier).state = AsyncValue.data(
           reviews,
         );
       } else {
         throw Exception(
-          'Failed to load accepted reviews: ${response.statusCode}',
+          'Failed to load received reviews: ${response.statusCode}',
         );
       }
     } catch (e, stack) {
-      ref.read(acceptedReviewsProvider.notifier).state = AsyncValue.error(
+      ref.read(receivedReviewsProvider.notifier).state = AsyncValue.error(
         e,
         stack,
       );
-    }
-  }
-
-  // レビューを承認する
-  Future<bool> acceptReview(String reviewId) async {
-    // モック時は即成功にしてリストをリフレッシュ
-    if (_useMockAcceptedReviews) {
-      await Future.delayed(const Duration(milliseconds: 200));
-      await fetchAcceptedReviews();
-      return true;
-    }
-
-    try {
-      // TODO: 実際のAPIエンドポイントに置き換える
-      final response = await http.post(
-        Uri.parse('http://localhost:8080/api/reviews/$reviewId/accept'),
-        headers: {
-          'Content-Type': 'application/json',
-          // TODO: 認証トークンを追加
-          // 'Authorization': 'Bearer $token',
-        },
-      );
-
-      if (response.statusCode == 200) {
-        // 承認後、リストを再取得
-        await fetchAcceptedReviews();
-        return true;
-      } else {
-        return false;
-      }
-    } catch (e) {
-      return false;
     }
   }
 }


### PR DESCRIPTION
## 概要
- 承認済みレビューの名称を受信レビューに統一
- acceptReview を削除して受信レビュー一覧のみの構成に変更
- 一覧画面とプロバイダー名を受信レビューに整理

## 影響範囲
- mobile/lib/features/review/received_review_list_page.dart
- mobile/lib/features/review/review_service.dart
- mobile/lib/features/home/home_page.dart

## 動作確認
- 未実施（UI変更）