### PR TITLE
プロフィールタブの自己紹介の周りの枠を削除 (issue #92)

### DIFF
--- a/mobile/lib/features/profile/profile_display_page.dart
+++ b/mobile/lib/features/profile/profile_display_page.dart
@@ -112,7 +112,6 @@ class _ProfileDisplayPageState extends ConsumerState<ProfileDisplayPage> {
                     ),
                     const SizedBox(height: 24),
                     // 自己紹介
-                    // 自己紹介
                     SizedBox(
                       width: double.infinity,
                       child: Column(


### PR DESCRIPTION
プロフィールタブの自己紹介の周りの枠を削除