### PR TITLE
fix: logout redirects to login

### DIFF
--- a/mobile/lib/features/home/home_page.dart
+++ b/mobile/lib/features/home/home_page.dart
@@ -18,8 +18,10 @@ class HomePage extends ConsumerStatefulWidget {
 class _HomePageState extends ConsumerState<HomePage> {
   int _index = 0;
 
-  void _handleLogout() {
-    ref.read(authControllerProvider.notifier).logout();
+  Future<void> _handleLogout() async {
+    await ref.read(authControllerProvider.notifier).logout();
+    if (!mounted) return;
+    Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
   }
 
   @override


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要

ログアウト時に必ず LoginPage へ遷移し、ナビゲーションスタックをクリアするようにしました。

# やったこと

- [x] ログアウト処理で LoginPage へ pushAndRemoveUntil するように変更

# 関連する Issue

- Close #（未設定）

# 確認したこと

- [ ] 未確認（手動確認予定）

# UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="200" /> | <img src="" width="200" /> |

# コメント

- なし

# メモ

- なし

<!-- I want to review in Japanese. -->
