### PR TITLE
新規登録エラーを画面上部のテキストで明示表示

### DIFF
--- a/mobile/lib/features/auth/auth_service.dart
+++ b/mobile/lib/features/auth/auth_service.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
@@ -136,15 +138,54 @@ class AuthService {
           .timeout(const Duration(seconds: 8));
 
       if (res.statusCode < 200 || res.statusCode >= 300) {
-        throw Exception('新規登録に失敗: ${res.statusCode} ${res.body}');
+        final serverError = _extractErrorMessage(res.body);
+        final userMessage = _signupErrorMessage(res.statusCode, serverError);
+        throw SignUpException(
+          userMessage,
+          statusCode: res.statusCode,
+          serverMessage: serverError,
+        );
       }
 
       final decoded = jsonDecode(res.body);
       if (decoded is! Map<String, dynamic>) {
-        throw Exception('新規登録の応答が不正です');
+        throw SignUpException(
+          'サーバーの応答形式が不正です。',
+          statusCode: res.statusCode,
+          serverMessage: res.body,
+        );
       }
 
-      return SignUpResult.fromJson(decoded);
+      try {
+        return SignUpResult.fromJson(decoded);
+      } catch (e) {
+        throw SignUpException(
+          'サーバーの応答形式が不正です。',
+          statusCode: res.statusCode,
+          serverMessage: res.body,
+          cause: e,
+        );
+      }
+    } on TimeoutException catch (e) {
+      throw SignUpException(
+        '通信がタイムアウトしました。時間をおいて再試行してください。',
+        cause: e,
+      );
+    } on SocketException catch (e) {
+      throw SignUpException(
+        'ネットワークに接続できません。通信環境を確認してください。',
+        cause: e,
+      );
+    } on http.ClientException catch (e) {
+      throw SignUpException(
+        'ネットワークエラーが発生しました。',
+        cause: e,
+      );
+    } on FormatException catch (e) {
+      throw SignUpException(
+        'サーバーの応答形式が不正です。',
+        cause: e,
+      );
     } finally {
       if (_client == null) {
         client.close();
@@ -158,4 +199,53 @@ class AuthService {
     if (at <= 0) return trimmed;
     return trimmed.substring(0, at);
   }
+}
+
+class SignUpException implements Exception {
+  SignUpException(
+    this.userMessage, {
+    this.statusCode,
+    this.serverMessage,
+    this.cause,
+  });
+
+  final String userMessage;
+  final int? statusCode;
+  final String? serverMessage;
+  final Object? cause;
+
+  @override
+  String toString() => userMessage;
+}
+
+String? _extractErrorMessage(String body) {
+  if (body.trim().isEmpty) return null;
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is Map && decoded['error'] is String) {
+      return decoded['error'] as String;
+    }
+  } catch (_) {
+    // ignore parse errors and fall back to raw body.
+  }
+  return body;
+}
+
+String _signupErrorMessage(int statusCode, String? serverError) {
+  final normalized = serverError?.toLowerCase();
+  if (statusCode == 409 ||
+      (normalized != null && normalized.contains('email already registered'))) {
+    return 'このメールアドレスは既に使用されています。';
+  }
+  if (statusCode == 400 ||
+      (normalized != null && normalized.contains('invalid request'))) {
+    return '入力内容を確認してください。';
+  }
+  if (statusCode >= 500 ||
+      (normalized != null &&
+          (normalized.contains('database error') ||
+              normalized.contains('failed to create user')))) {
+    return 'サーバーで問題が発生しました。時間をおいて再度お試しください。';
+  }
+  return '新規登録に失敗しました。時間をおいて再度お試しください。';
 }

--- a/mobile/lib/register_screen.dart
+++ b/mobile/lib/register_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'features/onboarding/register_validation.dart';
 import 'features/auth/auth_controller.dart';
+import 'features/auth/auth_service.dart';
 import 'features/auth/models.dart';
 import 'profile_setup_screen.dart';
 
@@ -86,8 +87,11 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
       );
     } catch (e) {
       if (!mounted) return;
+      final message = e is SignUpException
+          ? e.userMessage
+          : '新規登録に失敗しました。通信状況を確認して再度お試しください。';
       setState(() {
-        _submitError = '新規登録に失敗しました。通信状況を確認して再度お試しください。';
+        _submitError = message;
       });
     } finally {
       if (mounted) setState(() => _isSubmitting = false);


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要

新規登録画面の送信エラーを画面上部のテキストで明示表示に変更

# やったこと

- [x] 新規登録失敗時のエラーをタイトル直下に表示
- [x] SnackBarでの失敗表示を削除
- [x] 入力変更時に送信エラーをクリア

# 関連する Issue

- Close # (該当なし)

# 確認したこと

- [ ] ローカル未確認

# UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="200" /> | <img src="" width="200" /> |

# コメント

- スクリーンショット未取得

# メモ

-

<!-- I want to review in Japanese. -->