### PR TITLE
Disable fallback when BACKEND_BASE_URL is missing

### DIFF
--- a/mobile/lib/features/auth/auth_service.dart
+++ b/mobile/lib/features/auth/auth_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import '../../config.dart';
@@ -22,13 +23,15 @@ class AuthService {
     required String email,
     required String password,
   }) async {
-    // backendが未完成な間は、URL未指定なら成功扱いにする。
     if (_effectiveBaseUrl.trim().isEmpty) {
-      await Future<void>.delayed(const Duration(milliseconds: 400));
-      final displayName = _guessDisplayName(email);
-      return AuthLoginResult(
-        user: AuthUser(id: email, email: email, displayName: displayName),
-      );
+      if (kDebugMode) {
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+        final displayName = _guessDisplayName(email);
+        return AuthLoginResult(
+          user: AuthUser(id: email, email: email, displayName: displayName),
+        );
+      }
+      throw Exception('BACKEND_BASE_URL が未設定です');
     }
 
     final Uri uri;
@@ -76,8 +79,11 @@ class AuthService {
 
   Future<LoginResult> loginWithEmailPassword(LoginRequest request) async {
     if (_effectiveBaseUrl.trim().isEmpty) {
-      await Future<void>.delayed(const Duration(milliseconds: 400));
-      return LoginResult(userId: request.email);
+      if (kDebugMode) {
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+        return LoginResult(userId: request.email);
+      }
+      throw Exception('BACKEND_BASE_URL が未設定です');
     }
 
     final Uri uri;
@@ -115,10 +121,12 @@ class AuthService {
   }
 
   Future<SignUpResult> signUp(SignUpRequest request) async {
-    // backendが未完成な間は、URL未指定なら成功扱いにする。
     if (_effectiveBaseUrl.trim().isEmpty) {
-      await Future<void>.delayed(const Duration(milliseconds: 400));
-      return SignUpResult(userId: request.username);
+      if (kDebugMode) {
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+        return SignUpResult(userId: request.username);
+      }
+      throw SignUpException('BACKEND_BASE_URL が未設定です');
     }
 
     final Uri uri;

--- a/mobile/lib/features/home/works_service.dart
+++ b/mobile/lib/features/home/works_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import '../../config.dart';
@@ -13,8 +14,11 @@ class WorksService {
 
   Future<List<Work>> getWorks({required String userId}) async {
     if (backendBaseUrl.trim().isEmpty) {
-      await Future<void>.delayed(const Duration(milliseconds: 250));
-      return _dummyWorks;
+      if (kDebugMode) {
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+        return _dummyWorks;
+      }
+      throw Exception('BACKEND_BASE_URL が未設定です');
     }
 
     final Uri base;


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要

BACKEND_BASE_URL 未設定時の擬似ログイン/ダミー作品を debug 時のみ有効化。

# やったこと

- [x] `AuthService` のフォールバックを `kDebugMode` 限定に変更
- [x] `WorksService` のダミー作品フォールバックを `kDebugMode` 限定に変更

# 関連する Issue

- Close #139

# 確認したこと

- [ ] 未実施（ローカル確認のみ）

# UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| N/A | N/A |

# コメント

- 本番では未設定時にエラー表示されるようになります

# メモ

- 

<!-- I want to review in Japanese. -->
