### PR TITLE
matches APIのレビュー状態UI対応

### DIFF
--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -338,10 +338,9 @@ class _ReviewTargetCard extends StatelessWidget {
 }
 
 class _ReviewStatusTag extends StatelessWidget {
-  const _ReviewStatusTag({required this.isReviewed});
-
   final bool isReviewed;
 
+  const _ReviewStatusTag({required this.isReviewed});
   @override
   Widget build(BuildContext context) {
     final label = isReviewed ? 'レビュー済み' : '未レビュー';

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -250,10 +250,12 @@ class _ReviewTargetCard extends StatelessWidget {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Opacity(
         opacity: isEnabled ? 1 : 0.6,
-        child: Semantics(
-          button: true,
-          enabled: isEnabled,
-          child: InkWell(
+        child: ExcludeSemantics(
+          excluding: !isEnabled,
+          child: Semantics(
+            button: true,
+            enabled: isEnabled,
+            child: InkWell(
             onTap: isEnabled
                 ? () {
                     Navigator.push(
@@ -306,6 +308,7 @@ class _ReviewTargetCard extends StatelessWidget {
                   _WorkPreview(imageUrl: target.workImageUrl),
                 ],
               ),
+            ),
             ),
           ),
         ),

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -250,58 +250,62 @@ class _ReviewTargetCard extends StatelessWidget {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Opacity(
         opacity: isEnabled ? 1 : 0.6,
-        child: InkWell(
-          onTap: isEnabled
-              ? () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => ReviewExecutionScreen(
-                        matchId: target.matchId,
-                        artworkImageUrl: target.workImageUrl,
-                        artworkTitle: target.workTitle.isNotEmpty
-                            ? target.workTitle
-                            : '作品',
-                        artistName: target.username,
-                      ),
-                    ),
-                  );
-                }
-              : null,
-          borderRadius: BorderRadius.circular(12),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Row(
-              children: [
-                CircleAvatar(
-                  backgroundColor: Theme.of(context).primaryColor,
-                  child: _AvatarContent(
-                    imageUrl: target.iconUrl,
-                    fallbackText: target.username.isNotEmpty
-                        ? target.username[0].toUpperCase()
-                        : '?',
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        target.username,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
+        child: Semantics(
+          button: true,
+          enabled: isEnabled,
+          child: InkWell(
+            onTap: isEnabled
+                ? () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ReviewExecutionScreen(
+                          matchId: target.matchId,
+                          artworkImageUrl: target.workImageUrl,
+                          artworkTitle: target.workTitle.isNotEmpty
+                              ? target.workTitle
+                              : '作品',
+                          artistName: target.username,
                         ),
                       ),
-                      const SizedBox(height: 6),
-                      _ReviewStatusTag(isReviewed: target.isReviewed),
-                    ],
+                    );
+                  }
+                : null,
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  CircleAvatar(
+                    backgroundColor: Theme.of(context).primaryColor,
+                    child: _AvatarContent(
+                      imageUrl: target.iconUrl,
+                      fallbackText: target.username.isNotEmpty
+                          ? target.username[0].toUpperCase()
+                          : '?',
+                    ),
                   ),
-                ),
-                const SizedBox(width: 12),
-                _WorkPreview(imageUrl: target.workImageUrl),
-              ],
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          target.username,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                          ),
+                        ),
+                        const SizedBox(height: 6),
+                        _ReviewStatusTag(isReviewed: target.isReviewed),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  _WorkPreview(imageUrl: target.workImageUrl),
+                ],
+              ),
             ),
           ),
         ),

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -322,19 +322,22 @@ class _ReviewStatusTag extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final label = isReviewed ? 'レビュー済み' : '未レビュー';
-    final color = isReviewed ? Colors.grey : Colors.orange;
+    final borderColor =
+        isReviewed ? Colors.grey.shade700 : Colors.orange.shade700;
+    final backgroundColor =
+        isReviewed ? Colors.grey.shade200 : Colors.orange.shade100;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.15),
+        color: backgroundColor,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color),
+        border: Border.all(color: borderColor),
       ),
       child: Text(
         label,
         style: TextStyle(
           fontSize: 12,
-          color: color,
+          color: borderColor,
           fontWeight: FontWeight.w600,
         ),
       ),

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -282,7 +282,14 @@ class _ReviewTargetCard extends StatelessWidget {
                         ),
                       );
                       if (context.mounted) {
-                        await onReviewCompleted?.call();
+                        try {
+                          await onReviewCompleted?.call();
+                        } catch (e, stackTrace) {
+                          if (kDebugMode) {
+                            debugPrint('onReviewCompleted 実行中にエラーが発生しました: $e');
+                            debugPrint('$stackTrace');
+                          }
+                        }
                       }
                     }
                   : null,

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -302,7 +302,7 @@ class _ReviewTargetCard extends StatelessWidget {
                 const SizedBox(width: 12),
                 _WorkPreview(imageUrl: target.workImageUrl),
               ],
-            ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -151,8 +151,11 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
       }
 
       targets.sort((a, b) {
-        if (a.isReviewed == b.isReviewed) return 0;
-        return a.isReviewed ? 1 : -1;
+        // まず未レビューを優先し、同じレビュー状態であれば matchId で安定ソートする
+        if (a.isReviewed != b.isReviewed) {
+          return a.isReviewed ? 1 : -1;
+        }
+        return a.matchId.compareTo(b.matchId);
       });
 
       if (!mounted) return;

--- a/mobile/lib/review_screen.dart
+++ b/mobile/lib/review_screen.dart
@@ -229,7 +229,10 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
         padding: const EdgeInsets.all(16),
         itemBuilder: (context, index) {
           final target = _targets[index];
-          return _ReviewTargetCard(target: target);
+          return _ReviewTargetCard(
+            target: target,
+            onReviewCompleted: _fetchMatches,
+          );
         },
       ),
     );
@@ -238,8 +241,12 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
 
 class _ReviewTargetCard extends StatelessWidget {
   final MatchTarget target;
+  final Future<void> Function()? onReviewCompleted;
 
-  const _ReviewTargetCard({required this.target});
+  const _ReviewTargetCard({
+    required this.target,
+    this.onReviewCompleted,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -256,59 +263,62 @@ class _ReviewTargetCard extends StatelessWidget {
             button: true,
             enabled: isEnabled,
             child: InkWell(
-            onTap: isEnabled
-                ? () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => ReviewExecutionScreen(
-                          matchId: target.matchId,
-                          artworkImageUrl: target.workImageUrl,
-                          artworkTitle: target.workTitle.isNotEmpty
-                              ? target.workTitle
-                              : '作品',
-                          artistName: target.username,
-                        ),
-                      ),
-                    );
-                  }
-                : null,
-            borderRadius: BorderRadius.circular(12),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                children: [
-                  CircleAvatar(
-                    backgroundColor: Theme.of(context).primaryColor,
-                    child: _AvatarContent(
-                      imageUrl: target.iconUrl,
-                      fallbackText: target.username.isNotEmpty
-                          ? target.username[0].toUpperCase()
-                          : '?',
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          target.username,
-                          style: const TextStyle(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 16,
+              onTap: isEnabled
+                  ? () async {
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => ReviewExecutionScreen(
+                            matchId: target.matchId,
+                            artworkImageUrl: target.workImageUrl,
+                            artworkTitle: target.workTitle.isNotEmpty
+                                ? target.workTitle
+                                : '作品',
+                            artistName: target.username,
                           ),
                         ),
-                        const SizedBox(height: 6),
-                        _ReviewStatusTag(isReviewed: target.isReviewed),
-                      ],
+                      );
+                      if (context.mounted) {
+                        await onReviewCompleted?.call();
+                      }
+                    }
+                  : null,
+              borderRadius: BorderRadius.circular(12),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    CircleAvatar(
+                      backgroundColor: Theme.of(context).primaryColor,
+                      child: _AvatarContent(
+                        imageUrl: target.iconUrl,
+                        fallbackText: target.username.isNotEmpty
+                            ? target.username[0].toUpperCase()
+                            : '?',
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  _WorkPreview(imageUrl: target.workImageUrl),
-                ],
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            target.username,
+                            style: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          _ReviewStatusTag(isReviewed: target.isReviewed),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    _WorkPreview(imageUrl: target.workImageUrl),
+                  ],
+                ),
               ),
-            ),
             ),
           ),
         ),


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

# 概要

matches API 仕様変更に合わせ、レビュー状態の表示・タップ制御・タイトル反映を追加。

# やったこと

- [x] matchesレスポンスに work_title / is_reviewed を追加対応
- [x] 未レビュー優先で並び替え
- [x] レビュー状態タグ表示（未レビュー/レビュー済み）
- [x] レビュー済みはタップ不可
- [x] 詳細画面で作品タイトルを本番データに反映

# 関連する Issue

- Close #（未指定）

# 確認したこと

- [ ] 未実施（動作確認はこれから）

# UI 差分

|           Before           |           After            |
| :------------------------: | :------------------------: |
| 未撮影 | 未撮影 |

# コメント

-

# メモ

-

<!-- I want to review in Japanese. -->
